### PR TITLE
small bugfix, an undefined value now results in an error

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -28,7 +28,7 @@ function toLiteral(val: any): string {
         case 'number':
             return val.toString(10);
         default:
-            if (nullIsh(val === null)) {
+            if (nullIsh(val)) {
                 return 'null';
             }
             if (Array.isArray(val)) {


### PR DESCRIPTION
small bugfix, an undefined value now results in an error as `nullish (undefined === null)` =>` nullish (false)` => `false`