### PR TITLE
Fix timestamptz typo

### DIFF
--- a/src/datatypes/datatypes.ts
+++ b/src/datatypes/datatypes.ts
@@ -532,7 +532,7 @@ export const Types = {
     [DataType.text]: (len: number | nil = null) => makeText(len) as _IType,
     [DataType.citext]: new TextType(null, true),
     [DataType.timestamp]: new TimestampType(DataType.timestamp) as _IType,
-    [DataType.timestampz]: new TimestampType(DataType.timestampz) as _IType,
+    [DataType.timestamptz]: new TimestampType(DataType.timestamptz) as _IType,
     [DataType.uuid]: new UUIDtype() as _IType,
     [DataType.date]: new TimestampType(DataType.date) as _IType,
     [DataType.interval]: new IntervalType() as _IType,
@@ -608,8 +608,8 @@ export const typeSynonyms: { [key: string]: DataType } = {
     'real': DataType.float,
     'money': DataType.float,
 
-    'timestampz': DataType.timestamp, //  => todo support timestampz
-    'timestamp with time zone': DataType.timestamp, //  => todo support timestampz
+    'timestamptz': DataType.timestamp, //  => todo support timestamptz
+    'timestamp with time zone': DataType.timestamp, //  => todo support timestamptz
     'timestamp without time zone': DataType.timestamp,
 
     'boolean': DataType.bool,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,7 +43,7 @@ export enum DataType {
     bytea = 'bytea',
     interval = 'interval',
     timestamp = 'timestamp',
-    timestampz = 'timestampz',
+    timestamptz = 'timestamptz',
     date = 'date',
     time = 'time',
     null = 'null',

--- a/src/tests/various-expressions.spec.ts
+++ b/src/tests/various-expressions.spec.ts
@@ -73,5 +73,7 @@ describe('Various expressions', () => {
 
         expectSingle(`SELECT EXTRACT(YEAR FROM TIMESTAMP '2001-02-16 20:38:40')`, 2001);
 
+        expectSingle(`SELECT EXTRACT(YEAR FROM TIMESTAMPTZ '2001-02-16 20:38:40')`, 2001);
+
     })
 });


### PR DESCRIPTION
This PR resolves a typo in the `timestamptz` implementation that was discovered in issue https://github.com/oguimbal/pg-mem/issues/68. It also adds a test case verifying the usage of the keyword.