### PR TITLE
Introduce the column manager for tables

### DIFF
--- a/src/column.ts
+++ b/src/column.ts
@@ -169,14 +169,13 @@ export class ColRef implements _Column {
         this.expression = columnEvaluator(this.table, newId, newType);
 
         // replace in table
-        this.table.columnsByName.delete(on);
-        this.table.columnsByName.set(nn, this);
+        this.table.columnMgr.delete(on);
+        this.table.columnMgr.set(nn, this);
     }
 
     drop(t: _Transaction): void {
         const on = this.expression.id!;
-        const i = this.table.columnDefs.indexOf(this);
-        if (i < 0) {
+        if (!this.table.columnMgr.has(on)) {
             throw new Error('Corrupted table');
         }
 
@@ -189,9 +188,7 @@ export class ColRef implements _Column {
         this.table.remapData(t, x => delete x[this.expression.id!]);
 
         // nasty business to remove columns
-        this.table.columnsByName.delete(on);
-        this.table.columnDefs.splice(i, 1);
-        this.table.columns.splice(i, 1);
+        this.table.columnMgr.delete(on);
         this.table.selection.rebuild();
         this.drophandlers.forEach(d => d(t));
         this.table.db.onSchemaChange();

--- a/src/interfaces-private.ts
+++ b/src/interfaces-private.ts
@@ -365,7 +365,6 @@ export interface _ITable<T = any> extends IMemoryTable<T>, _RelationBase {
     readonly hidden: boolean;
     readonly db: _IDb;
     readonly selection: _ISelection<T>;
-    readonly columnDefs: _Column[];
     readonly ownerSchema: _ISchema;
     doInsert(t: _Transaction, toInsert: T, opts?: ChangeOpts): T;
     setHidden(): this;
@@ -578,7 +577,6 @@ export interface TableRecordDef<T> {
     it: number;
     indexByHash: ImMap<string, _IIndex<T>>;
     indexByName: ImMap<string, _IIndex<T>>;
-    columnDefs: List<string>;
     columnsByName: ImMap<string, CR<T>>;
 }
 
@@ -597,7 +595,6 @@ export const EmtpyTable = Record<TableRecordDef<any>>({
     it: 0,
     indexByHash: ImMap(),
     indexByName: ImMap(),
-    columnDefs: List(),
     columnsByName: ImMap(),
 });
 

--- a/src/schema/readonly-table.ts
+++ b/src/schema/readonly-table.ts
@@ -80,10 +80,6 @@ export abstract class ReadOnlyTable<T = any> extends DataSourceBase<T> implement
         throw new NotSupported('stats (count, ...) on information schema');
     }
 
-    get columnDefs(): _Column[] {
-        throw new PermissionDeniedError(this.name);
-    }
-
     rename(to: string): this {
         throw new PermissionDeniedError(this.name);
     }

--- a/src/table.ts
+++ b/src/table.ts
@@ -28,33 +28,33 @@ interface ChangePlan<T> {
 }
 
 class ColumnManager {
-  private _columns?: IValue[];
-  readonly map = new Map<string, ColRef>();
+    private _columns?: readonly IValue[];
+    readonly map = new Map<string, ColRef>();
 
-  get columns(): IValue[] {
-    if (!this._columns) {
-      this._columns = Object.freeze(Array.from(this.map.values(), c => c.expression));
+    get columns(): readonly IValue[] {
+        if (!this._columns) {
+            this._columns = Object.freeze(Array.from(this.map.values(), c => c.expression));
+        }
+        return this._columns!;
     }
-    return this._columns;
-  }
-  invalidateColumns() {
-    this._columns = undefined;
-  }
+    invalidateColumns() {
+        this._columns = undefined;
+    }
 
-  // Pass-through methods
-  get = this.map.get.bind(this.map);
-  has = this.map.has.bind(this.map)
-  values = this.map.values.bind(this.map);
+    // Pass-through methods
+    get = this.map.get.bind(this.map);
+    has = this.map.has.bind(this.map)
+    values = this.map.values.bind(this.map);
 
-  set(name: string, colDef: ColRef) {
-    this.invalidateColumns();
-    return this.map.set(name, colDef);
-  }
+    set(name: string, colDef: ColRef) {
+        this.invalidateColumns();
+        return this.map.set(name, colDef);
+    }
 
-  delete(name: string) {
-    this.invalidateColumns();
-    return this.map.delete(name);
-  }
+    delete(name: string) {
+        this.invalidateColumns();
+        return this.map.delete(name);
+    }
 }
 
 export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTable, _ITable<T> {
@@ -70,7 +70,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         return this._reg;
     }
     get columns() {
-      return this.columnMgr.columns;
+        return this.columnMgr.columns;
     }
     private it = 0;
     private cstGen = 0;

--- a/src/table.ts
+++ b/src/table.ts
@@ -12,7 +12,6 @@ import { DataSourceBase } from './transforms/transform-base';
 import { parseSql } from './parse-cache';
 import { ForeignKey } from './constraints/foreign-key';
 import { Types } from './datatypes';
-import moment from 'moment';
 
 
 type Raw<T> = ImMap<string, T>;
@@ -27,6 +26,37 @@ interface ChangePlan<T> {
     before(): void
     after(): void;
 }
+
+class ColumnManager {
+  private _columns?: IValue[];
+  readonly map = new Map<string, ColRef>();
+
+  get columns(): IValue[] {
+    if (!this._columns) {
+      this._columns = Object.freeze(Array.from(this.map.values(), c => c.expression));
+    }
+    return this._columns;
+  }
+  invalidateColumns() {
+    this._columns = undefined;
+  }
+
+  // Pass-through methods
+  get = this.map.get.bind(this.map);
+  has = this.map.has.bind(this.map)
+  values = this.map.values.bind(this.map);
+
+  set(name: string, colDef: ColRef) {
+    this.invalidateColumns();
+    return this.map.set(name, colDef);
+  }
+
+  delete(name: string) {
+    this.invalidateColumns();
+    return this.map.delete(name);
+  }
+}
+
 export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTable, _ITable<T> {
 
 
@@ -39,6 +69,9 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         }
         return this._reg;
     }
+    get columns() {
+      return this.columnMgr.columns;
+    }
     private it = 0;
     private cstGen = 0;
     hasPrimary = false;
@@ -50,11 +83,9 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         index: BIndex<T>;
         expressions: IValue[];
     }>();
-    columnDefs: ColRef[] = [];
-    columnsByName = new Map<string, ColRef>();
+    readonly columnMgr = new ColumnManager();
     name: string;
 
-    readonly columns: IValue[] = [];
     private changeHandlers = new Map<_Column | null, ChangeSub<T>>();
     private truncateHandlers = new Set<DropHandler>();
     private drophandlers = new Set<DropHandler>();
@@ -123,7 +154,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
     getColumn(column: string | ExprRef): IValue;
     getColumn(column: string | ExprRef, nullIfNotFound?: boolean): IValue | nil;
     getColumn(column: string | ExprRef, nullIfNotFound?: boolean): IValue<any> | nil {
-        return colByName(this.columnsByName, column, nullIfNotFound)
+        return colByName(this.columnMgr.map, column, nullIfNotFound)
             ?.expression;
     }
 
@@ -145,7 +176,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
             return this.addColumn(tp, t);
         }
 
-        if (this.columnsByName.has(column.name)) {
+        if (this.columnMgr.has(column.name)) {
             throw new QueryError(`Column "${column.name}" already exists`);
         }
         const cref = new ColRef(this, columnEvaluator(this.selection, column.name, column.type as _IType), column, column.name);
@@ -156,8 +187,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
             t.set(this.serialsId, t.getMap(this.serialsId).set(column.name, 0));
         }
 
-        this.columnDefs.push(cref);
-        this.columnsByName.set(column.name, cref);
+        this.columnMgr.set(column.name, cref);
 
         try {
             if (column.constraints?.length) {
@@ -168,13 +198,11 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
                 this.remapData(t, x => (x as any)[column.name] = (x as any)[column.name] ?? null);
             }
         } catch (e) {
-            this.columnDefs.pop();
-            this.columnsByName.delete(column.name);
+            this.columnMgr.delete(column.name);
             throw e;
         }
 
         // once constraints created, reference them. (constraint creation might have thrown)m
-        this.columns.push(cref.expression);
         this.db.onSchemaChange();
         this.selection.rebuild();
         return cref;
@@ -184,7 +212,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
     getColumnRef(column: string): ColRef;
     getColumnRef(column: string, nullIfNotFound?: boolean): ColRef | nil;
     getColumnRef(column: string, nullIfNotFound?: boolean): ColRef | nil {
-        const got = this.columnsByName.get(column);
+        const got = this.columnMgr.get(column);
         if (!got) {
             if (nullIfNotFound) {
                 return null;
@@ -280,7 +308,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         t.set(this.serialsId, serials);
 
         // set default values
-        for (const c of this.columnDefs) {
+        for (const c of this.columnMgr.values()) {
             c.setDefaults(toInsert, t);
         }
 
@@ -319,7 +347,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         }
 
         // check constraints
-        for (const c of this.columnDefs) {
+        for (const c of this.columnMgr.values()) {
             c.checkConstraints(toInsert, t);
         }
 
@@ -343,7 +371,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
             if (global) {
                 ret.push(global);
             }
-            for (const def of this.columnDefs) {
+            for (const def of this.columnMgr.values()) {
                 const h = this.changeHandlers.get(def);
                 if (!h) {
                     continue;
@@ -394,7 +422,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         const exists = bin.get(id) ?? null;
 
         // set default values
-        for (const c of this.columnDefs) {
+        for (const c of this.columnMgr.values()) {
             c.setDefaults(toUpdate, t);
         }
 
@@ -407,7 +435,7 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
 
 
         // check constraints
-        for (const c of this.columnDefs) {
+        for (const c of this.columnMgr.values()) {
             c.checkConstraints(toUpdate, t);
         }
 


### PR DESCRIPTION
As a follow-up for #98, I propose to use a column manager which would be the central point to maintain this column list as:
 - a map for the association of the name with the column definition;
 - a column definition list (whose computation is cached);

When the map is mutated, the column definition list cache is invalidated.

I managed to remove the columnDefs, as the map values are ordered by their insertion time.

What do you think? (feedback welcome! :) )