### PR TITLE
update: forward knex config

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -4,7 +4,6 @@ import moment from 'moment';
 import lru from 'lru-cache';
 import { bufToString, isBuf } from './buffer-node';
 import { compareVersions, nullIsh } from './utils';
-import Knex from 'knex';
 declare var __non_webpack_require__: any;
 
 const delay = (time: number | undefined) => new Promise(done => setTimeout(done, time ?? 0));
@@ -287,7 +286,7 @@ export class Adapters implements LibAdapters {
         }
     }
 
-    createKnex(queryLatency?: number, knexConfig?: Knex.Config): any {
+    createKnex(queryLatency?: number, knexConfig?: object): any {
         const knex = __non_webpack_require__('knex')({
             connection: {},
             ...knexConfig,

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import lru from 'lru-cache';
 import { bufToString, isBuf } from './buffer-node';
 import { compareVersions, nullIsh } from './utils';
+import Knex from 'knex';
 declare var __non_webpack_require__: any;
 
 const delay = (time: number | undefined) => new Promise(done => setTimeout(done, time ?? 0));
@@ -286,10 +287,11 @@ export class Adapters implements LibAdapters {
         }
     }
 
-    createKnex(queryLatency?: number): any {
+    createKnex(queryLatency?: number, knexConfig?: Knex.Config): any {
         const knex = __non_webpack_require__('knex')({
-            client: 'pg',
             connection: {},
+            ...knexConfig,
+            client: 'pg',
         });
         knex.client.driver = this.createPg(queryLatency);
         knex.client.version = 'pg-mem';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 import { IMigrate } from './migrate/migrate-interfaces';
 import { TableConstraint, CreateColumnDef, NodeLocation, DataTypeDef, FunctionArgumentMode } from 'pgsql-ast-parser';
+import Knex from 'knex';
 
 
 export type nil = undefined | null;
@@ -208,7 +209,7 @@ export interface LibAdapters {
     createTypeormConnection(typeOrmConnection: any, queryLatency?: number): any;
 
     /** Create a Knex.js instance bound to this db */
-    createKnex(queryLatency?: number): any;
+    createKnex(queryLatency?: number, knexConfig?: Knex.Config): any;
 
     /** Create a mikro-orm instance bound to this db */
     createMikroOrm(mikroOrmOptions: any, queryLatency?: number): Promise<any>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,5 @@
 import { IMigrate } from './migrate/migrate-interfaces';
 import { TableConstraint, CreateColumnDef, NodeLocation, DataTypeDef, FunctionArgumentMode } from 'pgsql-ast-parser';
-import Knex from 'knex';
 
 
 export type nil = undefined | null;
@@ -209,7 +208,7 @@ export interface LibAdapters {
     createTypeormConnection(typeOrmConnection: any, queryLatency?: number): any;
 
     /** Create a Knex.js instance bound to this db */
-    createKnex(queryLatency?: number, knexConfig?: Knex.Config): any;
+    createKnex(queryLatency?: number, knexConfig?: object): any;
 
     /** Create a mikro-orm instance bound to this db */
     createMikroOrm(mikroOrmOptions: any, queryLatency?: number): Promise<any>

--- a/src/tests/knex-real.spec.ts
+++ b/src/tests/knex-real.spec.ts
@@ -37,4 +37,20 @@ describe('Knex', () => {
                 { id: 'gid', name: 'gname', user_id: 'uid', group_id: 'gid' }
             ]);
     })
+
+    it('should use knex config from parameter', async () => {
+        const mem = newDb();
+        const knex = mem.adapters.createKnex(
+          undefined,
+          {
+            migrations: {
+              tableName: 'example_table',
+              directory: '.example_migrations',
+            },
+          }
+        ) as import('knex');
+        const migrateConfig = (knex.migrate as any).config as { directory: string, tableName: string };
+        expect(migrateConfig.tableName).to.equal('example_table');
+        expect(migrateConfig.directory).to.equal('.example_migrations');
+    })
 });


### PR DESCRIPTION
Hey! Great library.

This PR adds support to pass custom config to `knex`. I have a use case in which the `migration` folder has a different name than default `migrations` and `pg-mem` doesn't support it yet.

Any doubts let me know.