### PR TITLE
Add array_agg support

### DIFF
--- a/src/tests/aggregations.spec.ts
+++ b/src/tests/aggregations.spec.ts
@@ -3,34 +3,31 @@ import 'chai';
 import { newDb } from '../db';
 import { expect, assert } from 'chai';
 import { _IDb } from '../interfaces-private';
-import { preventSeqScan } from './test-utils';
 
 describe('Aggregations', () => {
 
     let db: _IDb;
     let many: (str: string) => any[];
     let none: (str: string) => void;
-    let one: (str: string) => any;
+
     beforeEach(() => {
         db = newDb() as _IDb;
         many = db.public.many.bind(db.public);
         none = db.public.none.bind(db.public);
-        one = db.public.one.bind(db.public);
     });
-
 
     it('supports max()', () => {
         expect(many(`create table example(a int);
                     insert into example values (3), (null), (1), (5), (2);
                     select max(a) from example`))
             .to.deep.equal([{ max: 5 }]);
-    })
+    });
 
     it('max() returns null when nothing', () => {
         expect(many(`create table example(a int);
                     select max(a) from example`))
             .to.deep.equal([{ max: null }]);
-    })
+    });
 
 
     it('supports min()', () => {
@@ -38,20 +35,20 @@ describe('Aggregations', () => {
                     insert into example values (3), (null), (1), (5), (2);
                     select min(a) from example`))
             .to.deep.equal([{ min: 1 }]);
-    })
+    });
 
     it('min() returns null when nothing', () => {
         expect(many(`create table example(a int);
                     select min(a) from example`))
             .to.deep.equal([{ min: null }]);
-    })
+    });
 
     it('supports sum()', () => {
         expect(many(`create table example(a int);
                   insert into example values (1), (-2), (null), (3), (-4), (5);
                   select sum(a) from example`))
             .to.deep.equal([{ sum: 3 }])
-    })
+    });
 
 
     it('supports sum() in inner expression (simple)', () => {
@@ -59,7 +56,7 @@ describe('Aggregations', () => {
                   insert into example values (1), (2);
                   select 3+sum(a) as sum from example`))
             .to.deep.equal([{ sum: 6 }])
-    })
+    });
 
     it('supports sum() in inner expression (grouped by)', () => {
         expect(many(`create table example(id text, a int);
@@ -78,34 +75,34 @@ describe('Aggregations', () => {
             .to.deep.equal([
                 { sum: 6 },
             ]);
-    })
+    });
 
     it('supports aggregation with qualifier', () => {
         expect(many(`create table example(a int);
                   insert into example values (1), (-2), (null), (3), (-4), (5);
                   select pg_catalog.sum(a) from example`))
             .to.deep.equal([{ sum: 3 }]);
-    })
+    });
 
     it('throws error when aggregation function doest not exist', () => {
         none(`create table example(a int);
                   insert into example values (1), (-2), (null), (3), (-4), (5);`);
 
         assert.throws(() => none(`select public.sum(a) from example`), /function public\.sum\(integer\) does not exist/);
-    })
+    });
 
     it('sum() returns null when nothing', () => {
         expect(many(`create table example(a int);
                   select sum(a) from example`))
             .to.deep.equal([{ sum: null }]);
-    })
+    });
 
     it('supports sum(distinct())', () => {
         expect(many(`create table example(a int);
                 insert into example values (1), (1), (null), (2), (2), (3), (-1), (-1);
                 select sum(distinct(a)) from example`))
             .to.deep.equal([{ sum: 5 }])
-    })
+    });
 
     it('sum(distinct()) returns null when nothing', () => {
         expect(many(`create table example(a int);
@@ -124,5 +121,26 @@ describe('Aggregations', () => {
                 d: 2,
                 v: 5,
             }]);
+    });
+
+    it('supports array_agg()', () => {
+        expect(many(`create table example(a int, b int);
+                    insert into example values (1, 3), (1, 4);
+                    select array_agg(b) from example group by a`))
+            .to.deep.equal([{ array_agg: [3, 4] }]);
+    });
+
+    it('supports array_agg() with nulls', () => {
+        expect(many(`create table example(a int, b int);
+                    insert into example values (1, 3), (1, null);
+                    select array_agg(b) from example group by a`))
+            .to.deep.equal([{ array_agg: [3, null] }]);
+    });
+
+    it('supports array_agg() with multiple groups', () => {
+        expect(many(`create table example(a int, b int);
+                    insert into example values (1, 3), (1, 4), (2, 5);
+                    select array_agg(b) from example group by a`))
+            .to.deep.equal([{ array_agg: [3, 4] }, { array_agg: [5] }]);
     });
 });

--- a/src/transforms/aggregation.ts
+++ b/src/transforms/aggregation.ts
@@ -9,6 +9,7 @@ import { Evaluator } from '../evaluator';
 import { buildCount } from './aggregations/count';
 import { buildMinMax } from './aggregations/max-min';
 import { buildSum } from './aggregations/sum';
+import { buildArrayAgg } from './aggregations/array_agg';
 
 export const aggregationFunctions = new Set([
     'array_agg',
@@ -296,6 +297,8 @@ export class Aggregation<T> extends TransformBase<T> implements _ISelection<T> {
                 return buildMinMax(this.base, call.args, name);
             case 'sum':
                 return buildSum(this.base, call);
+            case 'array_agg':
+                return buildArrayAgg(this.base, call);
             default:
                 throw new NotSupported('aggregation function ' + name);
         }

--- a/src/transforms/aggregations/array_agg.ts
+++ b/src/transforms/aggregations/array_agg.ts
@@ -1,0 +1,37 @@
+import { AggregationComputer, AggregationGroupComputer, IValue, nil, QueryError, _ISelection, _IType, _Transaction } from '../../interfaces-private';
+import { Expr, ExprCall } from 'pgsql-ast-parser';
+import { buildValue } from '../../expression-builder';
+import { Types } from '../../datatypes';
+import { asSingleQName, nullIsh } from '../../utils';
+
+
+class ArrayAggExpr implements AggregationComputer<any[]> {
+
+    constructor(private exp: IValue) {
+    }
+
+    get type(): _IType<any> {
+        return Types.integer.asArray();
+    }
+
+    createGroup(t: _Transaction): AggregationGroupComputer<any[]> {
+        let val: any[] = [];
+        return {
+            feedItem: (item) => {
+                const value = this.exp.get(item, t);
+                val = [...val, value];
+            },
+            finish: () => val,
+        }
+    }
+}
+
+export function buildArrayAgg(this: void, base: _ISelection, call: ExprCall) {
+    const args = call.args;
+    if (args.length !== 1) {
+        throw new QueryError('ARRAY_AGG expects one argument, given ' + args.length);
+    }
+
+    const what = buildValue(base, args[0]);
+    return new ArrayAggExpr(what);
+}


### PR DESCRIPTION
❤️ to this library!
This is an initial implementation of an `array_agg` aggregation function since it does not support ordering inside. The ordering does not matter to me, just the function itself, so I thought that it can be merged like this (better than nothing) and then improved once refactoring is in place. If better to wait and have ordering support from scratch - feel free to reject this.