### PR TITLE
Also flag serial (autoincrement) when the type is bigserial

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -979,7 +979,7 @@ but the resulting statement cannot be executed → Probably not a pg-mem error.`
                             ...f,
                             name: f.name.name,
                             type: this.getType(f.dataType),
-                            serial: !f.dataType.kind && f.dataType.name === 'serial',
+                            serial: !f.dataType.kind && (f.dataType.name === 'serial' || f.dataType.name === 'bigserial'),
                         };
                         delete (nf as Optional<typeof nf>).dataType;
                         fields.push(nf);

--- a/src/tests/simple-queries.spec.ts
+++ b/src/tests/simple-queries.spec.ts
@@ -154,6 +154,12 @@ describe('Simple queries', () => {
             .to.deep.equal([{ id: 1, val: 'a' }, { id: 2, val: 'b' }]);
     });
 
+    it('supports bigserial data type', () => {
+        expect(many(`create table test(id bigserial primary key, val text, nl text);
+                                insert into test(val) values ('a'), ('b') returning id, val;`))
+            .to.deep.equal([{ id: 1, val: 'a' }, { id: 2, val: 'b' }]);
+    });
+
     it('can create two tables with different casing', () => {
         none(`create table example(id text);
             create table "Example"(val text);


### PR DESCRIPTION
Autoincrement works when the column is a `serial` type, but fails when it's `bigserial`. Small modification to detect that data type in the table creation.