### PR TITLE
Add precision support to timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lru-cache": "^6.0.0",
     "moment": "^2.27.0",
     "object-hash": "^2.0.3",
-    "pgsnpql-ast-parser": "^9.0.0"
+    "pgsql-ast-parser": "^9.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/datatypes/datatypes.ts
+++ b/src/datatypes/datatypes.ts
@@ -534,8 +534,8 @@ export const Types = {
     [DataType.bool]: new BoolType() as _IType,
     [DataType.text]: (len: number | nil = null) => makeText(len) as _IType,
     [DataType.citext]: new TextType(null, true),
-    [DataType.timestamp]: new TimestampType(DataType.timestamp) as _IType,
-    [DataType.timestamptz]: new TimestampType(DataType.timestamptz) as _IType,
+    [DataType.timestamp]: (len: number | nil = null) => makeTimestamp(DataType.timestamp, len) as _IType,
+    [DataType.timestamptz]: (len: number | nil = null) => makeTimestamp(DataType.timestamptz, len) as _IType,
     [DataType.uuid]: new UUIDtype() as _IType,
     [DataType.date]: new TimestampType(DataType.date) as _IType,
     [DataType.interval]: new IntervalType() as _IType,
@@ -580,6 +580,16 @@ function makeText(len: number | nil = null) {
     let got = texts.get(len);
     if (!got) {
         texts.set(len, got = new TextType(len));
+    }
+    return got;
+}
+
+const timestamps = new Map<number | null, _IType>();
+function makeTimestamp(primary: DataType, len: number | nil = null) {
+    len = len ?? null;
+    let got = timestamps.get(len);
+    if (!got) {
+        timestamps.set(len, got = new TimestampType(primary, len));
     }
     return got;
 }

--- a/src/datatypes/t-timestamp.ts
+++ b/src/datatypes/t-timestamp.ts
@@ -6,8 +6,15 @@ import moment from 'moment';
 export class TimestampType extends TypeBase<Date> {
 
 
-    constructor(readonly primary: DataType) {
+    constructor(readonly primary: DataType, readonly precision: number | null = null) {
         super();
+    }
+
+    get name(): string {
+        if (!this.precision) {
+            return this.primary;
+        }
+        return `${this.primary}(${this.precision})`;
     }
 
     doCanCast(to: _IType) {
@@ -71,7 +78,7 @@ export class TimestampType extends TypeBase<Date> {
                                 , toDate => ({ toDate }));
                 }
         }
-        return null;    
+        return null;
     }
 
 

--- a/src/expression-builder.ts
+++ b/src/expression-builder.ts
@@ -156,7 +156,7 @@ function buildKeyword(schema: _ISchema, kw: ExprValueKeyword, args: Expr[]): IVa
             return Value.constant(schema, Types.date, new Date());
         case 'current_timestamp':
         case 'localtimestamp':
-            return Value.constant(schema, Types.timestamp, new Date());
+            return Value.constant(schema, Types.timestamp(), new Date());
         case 'localtime':
         case 'current_time':
             throw new NotSupported('"date" data type, please file an issue in https://github.com/oguimbal/pg-mem if you need it !');
@@ -709,13 +709,13 @@ function buildExtract(data: _ISelection, op: ExprExtract): IValue {
         case 'doy':
             return extract(Types.date, x => moment.utc(x).dayOfYear());
         case 'epoch':
-            if (from.canConvert(Types.timestamp)) {
-                return extract(Types.timestamp, x => moment.utc(x).unix(), Types.float);
+            if (from.canConvert(Types.timestamp())) {
+                return extract(Types.timestamp(), x => moment.utc(x).unix(), Types.float);
             }
             return extract(Types.interval, (x: Interval) => intervalToSec(x));
         case 'hour':
-            if (from.canConvert(Types.timestamp)) {
-                return extract(Types.timestamp, x => moment.utc(x).hour());
+            if (from.canConvert(Types.timestamp())) {
+                return extract(Types.timestamp(), x => moment.utc(x).hour());
             }
             return extract(Types.interval, (x: Interval) => x.hours ?? 0);
         case 'isoyear':

--- a/src/schema/pg-catalog/index.ts
+++ b/src/schema/pg-catalog/index.ts
@@ -17,7 +17,7 @@ export function setupPgCatalog(db: _IDb) {
 
     catalog._registerType(Types.bool)
         ._registerType(Types.citext)
-        ._registerType(Types.timestamp)
+        ._registerTypeSizeable(DataType.timestamp, Types.timestamp)
         ._registerType(Types.uuid)
         ._registerType(Types.date)
         ._registerType(Types.time)

--- a/src/tests/conversions.spec.ts
+++ b/src/tests/conversions.spec.ts
@@ -179,4 +179,9 @@ describe('Conversions', () => {
         expect(many(`select array[]::text[] val`))
             .to.deep.equal([{ val: [] }]);
     })
+
+    it('can cast to timestamp with explicit precision', () => {
+        expect(many(`select '2021-09-18 00:00:00Z'::timestamp(4) with time zone val`))
+            .to.deep.equal([{ val: new Date('2021-09-18 00:00:00Z') }]);
+    })
 });


### PR DESCRIPTION
## Context

Update code to integrate precision support for timestamps offered by `pgsql-ast-parser@9.0.1`.

## Solution

* Use existing `_registerTypeSizeable` solution to add precision support to the timestamp data type.
* Add unit test for type conversion to a timestamp with explicit precision.

## Notes

Not sure why the package was called `pgsnpql-ast-parser` in `package.json`, but npm wouldn't install it so I changed it to the package's actual name. Let me know if this is intended and if I should revert my change.