### PR TITLE
fix: create table_constraints in information_schema, not pg_catalog

### DIFF
--- a/src/schema/information-schema/index.ts
+++ b/src/schema/information-schema/index.ts
@@ -2,6 +2,7 @@
 import { _IDb, _ISchema } from '../../interfaces-private';
 import { ColumnsListSchema } from './columns-list';
 import { TablesSchema } from './table-list';
+import { TableConstraints } from './table-constraints';
 
 export function setupInformationSchema(db: _IDb) {
     const schema: _ISchema = db.createSchema('information_schema');
@@ -9,6 +10,7 @@ export function setupInformationSchema(db: _IDb) {
     // SELECT * FROM "information_schema"."tables" WHERE ("table_schema" = 'public' AND "table_name" = 'user')
     new TablesSchema(schema).register();
     new ColumnsListSchema(schema).register();
+    new TableConstraints(schema).register();
 
     schema.setReadonly();
 }

--- a/src/schema/information-schema/table-constraints.ts
+++ b/src/schema/information-schema/table-constraints.ts
@@ -4,7 +4,7 @@ import { Types } from '../../datatypes';
 import { ReadOnlyTable } from '../readonly-table';
 
 // https://www.postgresql.org/docs/13/catalog-pg-range.html
-export class TableConstraint extends ReadOnlyTable implements _ITable {
+export class TableConstraints extends ReadOnlyTable implements _ITable {
 
 
     _schema: Schema = {

--- a/src/schema/pg-catalog/index.ts
+++ b/src/schema/pg-catalog/index.ts
@@ -12,7 +12,6 @@ import { sqlSubstring } from '../../parser/expression-builder';
 import { PgDatabaseTable } from './pg-database';
 import { registerCommonOperators } from './binary-operators';
 import { registerSqlFunctionLanguage } from './sql-function-language';
-import { TableConstraint } from './pg-table-constraint';
 
 
 export function setupPgCatalog(db: _IDb) {
@@ -53,7 +52,6 @@ export function setupPgCatalog(db: _IDb) {
     new PgTypeTable(catalog).register();
     new PgRange(catalog).register();
     new PgDatabaseTable(catalog).register();
-    new TableConstraint(catalog).register();
 
 
     // this is an ugly hack...


### PR DESCRIPTION
Fixes breakage with `sequelize@>=6.20.0`, see #227