### PR TITLE
feat: populate QueryResult.fields with names and types

### DIFF
--- a/src/execution/select.ts
+++ b/src/execution/select.ts
@@ -278,12 +278,20 @@ export class SelectExec implements _IStatementExecutor {
 
     execute(t: _Transaction): StatementResult {
         const rows = cleanResults([...this.selection.enumerate(t)]);
+        let unnamedFields = 0;
+        const nextDefaultFieldName = () => {
+            const unnamedField = `column${unnamedFields || ''}`;
+            unnamedFields += 1;
+            return unnamedField;
+        }
         return {
             result: {
                 rows,
                 rowCount: t.getTransient(MutationDataSourceBase.affectedRows) ?? rows.length,
                 command: this.p.type.toUpperCase(),
-                fields: [],
+                fields: this.selection.columns.map(
+                    c => ({ name: c.id ?? nextDefaultFieldName(), type: c.type.primary })
+                ),
                 location: locOf(this.p),
             },
             state: t,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -353,6 +353,7 @@ export interface QueryResult {
 
 export interface FieldInfo {
     name: string;
+    type: DataType;
 }
 
 


### PR DESCRIPTION
I found myself missing this in handling query results, and felt the simplest way to phrase the feature request was to write a test. I want to read both column names and types, for the query result.

Included is a draft implementation in `SelectExec` that satisfies this one test. But I notice that there is corresponding column naming logic in `src/transforms/selection.ts` with more involved name defaulting based on the column expressions, so I suspect probably that should be flowing through to the query result instead.

Fixes #234