### PR TITLE
Fix #237

### DIFF
--- a/src/adapters/adapters.ts
+++ b/src/adapters/adapters.ts
@@ -165,6 +165,9 @@ export class Adapters implements LibAdapters {
         };
     }
 
+    /**
+     * @deprecated Use `createTypeormDataSource` instead.
+     */
     createTypeormConnection(postgresOptions: any, queryLatency?: number) {
         const that = this;
         (postgresOptions as any).postgres = that.createPg(queryLatency);
@@ -176,6 +179,19 @@ export class Adapters implements LibAdapters {
         const created = getConnectionManager().create(postgresOptions);
         created.driver.postgres = that.createPg(queryLatency);
         return created.connect();
+    }
+
+    createTypeormDataSource(postgresOptions: any, queryLatency?: number) {
+        const that = this;
+        (postgresOptions as any).postgres = that.createPg(queryLatency);
+        if (postgresOptions?.type !== 'postgres') {
+            throw new NotSupported('Only postgres supported, found ' + postgresOptions?.type ?? '<null>')
+        }
+
+        const { DataSource } = __non_webpack_require__('typeorm')
+        const created = new DataSource(postgresOptions);
+        created.driver.postgres = that.createPg(queryLatency);
+        return created;
     }
 
     createSlonik(queryLatency?: number) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -208,8 +208,13 @@ export interface LibAdapters {
     /** Create a pg-native instance bound to this db */
     createPgNative(queryLatency?: number): any;
 
-    /** Create a Typeorm connection bound to this db */
+    /** Create a Typeorm connection bound to this db
+     * @deprecated Use `createTypeormDataSource` instead. See https://github.com/oguimbal/pg-mem/pull/238.
+     */
     createTypeormConnection(typeOrmConnection: any, queryLatency?: number): any;
+
+    /** Create a Typeorm data source bound to this db */
+    createTypeormDataSource(typeOrmConnection: any, queryLatency?: number): any;
 
     /** Create a Knex.js instance bound to this db */
     createKnex(queryLatency?: number, knexConfig?: object): any;


### PR DESCRIPTION
A fix for #237. For backwards compatibility, I left the old way of making a typeorm connection with `createTypeormConnection(options)` (but marked it as deprecated) and created a new adapter function `createTypeormDataSource(options)`.