### PR TITLE
fix broken build: constrain sequelize <6.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-monaco-editor": "^0.39.1",
         "reactjs-popup": "^1.5.0",
         "rimraf": "^3.0.2",
-        "sequelize": ">=6.3.5 <6.20.0",
+        "sequelize": ">=6.3.5 <6.14.0",
         "slonik": "^23.0.1",
         "source-map-support": "^0.5.19",
         "style-loader": "^1.2.1",
@@ -2348,12 +2348,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
-      "dev": true
-    },
-    "node_modules/@types/validator": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
-      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA==",
       "dev": true
     },
     "node_modules/@types/webpack": {
@@ -7680,9 +7674,9 @@
       "dev": true
     },
     "node_modules/inflection": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
-      "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
+      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==",
       "dev": true,
       "engines": [
         "node >= 0.4.0"
@@ -12142,9 +12136,9 @@
       }
     },
     "node_modules/sequelize": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.19.2.tgz",
-      "integrity": "sha512-799X+BsyloPzq1ooZQNJgevRYwdAla50+6MchUra28Mdw3xmc0NTj+16pb/cAaKDcQS2pgmyDn1ZePjP2wS0nA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.13.0.tgz",
+      "integrity": "sha512-p0dXXGZSc0Ng7CdGwlKN4P6DTRD/w9Ar2CnmHamNVDnqEWh6pMVOp3xrlG5+IWhbwrqL3SjIYEYt3Xog1vXRDw==",
       "dev": true,
       "funding": [
         {
@@ -12154,10 +12148,9 @@
       ],
       "dependencies": {
         "@types/debug": "^4.1.7",
-        "@types/validator": "^13.7.1",
         "debug": "^4.3.3",
         "dottie": "^2.0.2",
-        "inflection": "^1.13.2",
+        "inflection": "^1.13.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.34",
@@ -17185,12 +17178,6 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
-    "@types/validator": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.3.tgz",
-      "integrity": "sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA==",
-      "dev": true
-    },
     "@types/webpack": {
       "version": "4.41.21",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
@@ -21423,9 +21410,9 @@
       "dev": true
     },
     "inflection": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
-      "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
+      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==",
       "dev": true
     },
     "inflight": {
@@ -24946,16 +24933,15 @@
       }
     },
     "sequelize": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.19.2.tgz",
-      "integrity": "sha512-799X+BsyloPzq1ooZQNJgevRYwdAla50+6MchUra28Mdw3xmc0NTj+16pb/cAaKDcQS2pgmyDn1ZePjP2wS0nA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.13.0.tgz",
+      "integrity": "sha512-p0dXXGZSc0Ng7CdGwlKN4P6DTRD/w9Ar2CnmHamNVDnqEWh6pMVOp3xrlG5+IWhbwrqL3SjIYEYt3Xog1vXRDw==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.7",
-        "@types/validator": "^13.7.1",
         "debug": "^4.3.3",
         "dottie": "^2.0.2",
-        "inflection": "^1.13.2",
+        "inflection": "^1.13.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.34",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-monaco-editor": "^0.39.1",
     "reactjs-popup": "^1.5.0",
     "rimraf": "^3.0.2",
-    "sequelize": ">=6.3.5 <6.20.0",
+    "sequelize": ">=6.3.5 <6.14.0",
     "slonik": "^23.0.1",
     "source-map-support": "^0.5.19",
     "style-loader": "^1.2.1",


### PR DESCRIPTION
Constrain sequelize to versions earlier than [6.14.0][sequelize 6.14.0], because that version made this change:

> * **types:** drop TypeScript < 4.1 (#13954) (dd49044)

which breaks `npm run build-types` (and thus `npm run build`) in this project, making them emit a bunch of TypeScript errors such as:

```
node_modules/sequelize/dist/lib/model.d.ts:3032:19 - error TS1005: ']' expected.

3032   [Key in keyof M as
                       ~~

node_modules/sequelize/dist/lib/model.d.ts:3033:12 - error TS1005: ';' expected.

3033     M[Key] extends AnyFunction ? never
                ~~~~~~~

node_modules/sequelize/dist/lib/model.d.ts:3034:37 - error TS1005: ';' expected.

3034     : { [NonAttributeBrand]: true } extends M[Key] ? never
                                         ~~~~~~~
```
(etc.)

[sequelize 6.14.0]: https://github.com/sequelize/sequelize/releases/tag/v6.14.0