### PR TITLE
Populate code property in QueryError to match pg behavior

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -415,11 +415,16 @@ interface ErrorData {
 }
 export class QueryError extends Error {
     readonly data: ErrorData;
+    readonly code: string | undefined;
     constructor(err: string | ErrorData, code?: string) {
         super(typeof err === 'string' ? err : errDataToStr(err));
-        this.data = typeof err === 'string'
-            ? { error: err, code }
-            : err;
+        if (typeof err === 'string') {
+            this.data = { error: err, code };
+            this.code = code;
+        } else {
+            this.data = err;
+            this.code = err.code;
+        }
     }
 }
 


### PR DESCRIPTION
This is to make sure `sequelize` could recognize it as the same way as `pg`:
https://github.com/sequelize/sequelize/blob/3b14f1aa70e3a3991891e37431344e6f0db0089c/src/dialects/postgres/query.js#L323