### PR TITLE
fix: ORDER BY x ASC NULLS FIRST did not work

### DIFF
--- a/src/tests/order-by.queries.spec.ts
+++ b/src/tests/order-by.queries.spec.ts
@@ -72,6 +72,17 @@ describe('Order by', () => {
             ]);
     });
 
+    it('can order by asc with nulls first', () => {
+        expect(many(`create table test(val text);
+            insert into test values ('b'), ('a'), (null);
+            select t.val as value from test t order by t.val asc nulls first`))
+            .to.deep.equal([
+                { value: null }
+                , { value: 'a' }
+                , { value: 'b' }
+            ]);
+    });
+
     it('order by two columns', () => {
         expect(many(`create table test(a integer, b integer);
             insert into test values (1, 13), (2, 11), (1, null), (1, 11), (2, 12), (1, 12), (null, 1), (null, 5);

--- a/src/tests/order-by.queries.spec.ts
+++ b/src/tests/order-by.queries.spec.ts
@@ -50,7 +50,7 @@ describe('Order by', () => {
             ]);
     });
 
-    it('can order by with nulls last', () => {
+    it('can order by desc with nulls last', () => {
         expect(many(`create table test(val text);
             insert into test values ('b'), ('a'), (null);
             select t.val as value from test t order by t.val desc nulls last`))
@@ -61,7 +61,7 @@ describe('Order by', () => {
             ]);
     });
 
-    it('can order by with nulls first', () => {
+    it('can order by desc with nulls first', () => {
         expect(many(`create table test(val text);
             insert into test values ('b'), ('a'), (null);
             select t.val as value from test t order by t.val desc nulls first`))
@@ -69,6 +69,17 @@ describe('Order by', () => {
                 { value: null }
                 , { value: 'b' }
                 , { value: 'a' }
+            ]);
+    });
+
+    it('can order by asc with nulls last', () => {
+        expect(many(`create table test(val text);
+            insert into test values ('b'), ('a'), (null);
+            select t.val as value from test t order by t.val asc nulls last`))
+            .to.deep.equal([
+                { value: 'a' }
+                , { value: 'b' }
+                , { value: null }
             ]);
     });
 

--- a/src/transforms/order-by.ts
+++ b/src/transforms/order-by.ts
@@ -53,11 +53,14 @@ class OrderBy<T> extends FilterBase<any> implements _IAggregation {
     constructor(private selection: _ISelection<T>, order: OrderByStatement[]) {
         super(selection);
         this.order = withSelection(selection,
-            () => order.map(x => ({
-                by: buildValue(x.by),
-                order: x.order ?? 'ASC',
-                nullsLast: x.nulls === 'LAST',
-            })));
+            () => order.map(x => {
+                const order = x.order ?? 'ASC';
+                return ({
+                    by: buildValue(x.by),
+                    order,
+                    nullsLast: order === 'ASC' ? x.nulls !== 'FIRST' : x.nulls === 'LAST',
+                });
+            }));
     }
 
 
@@ -83,7 +86,7 @@ class OrderBy<T> extends FilterBase<any> implements _IAggregation {
                     continue;
                 }
                 if (na || nb) {
-                    return (o.order === 'ASC') === (nb === o.nullsLast) ? 1 : -1;
+                    return nb === o.nullsLast ? -1 : 1;
                 }
                 if (o.by.type.equals(aval, bval)) {
                     continue;


### PR DESCRIPTION
I discovered that `ORDER BY x ASC NULLS FIRST` did not work. This fixes that.