### PR TITLE
CI: remove EOL nodejs versions and add new major versions, update actions dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,18 +22,18 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 16.x, 18.x]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm


### PR DESCRIPTION
This PR : 
- remove nodejs version 10.x and 12.X because they are EOL and no more supported by the nodejs team (see https://github.com/nodejs/release#release-schedule). Even if many apps in the wild still use old versions of nodejs, it's generally not a good idea to keep the maintenance burden of unsupported versions. Many OSS projects drop support for these versions last months and the ecosystem is well aware of that.
- add supports for supported major versions of nodejs thus 14, 16 and 18 (AFAIK current version 19 is not supported in nodejs images in Actions)
- update actions node-setup, checkout and cache to last major version