### PR TITLE
Rebuild alias on column rename

### DIFF
--- a/src/column.ts
+++ b/src/column.ts
@@ -122,6 +122,7 @@ export class ColRef implements _Column {
         // === do nasty things to rename column
         this.replaceExpression(to, this.expression.type);
         this.table.db.onSchemaChange();
+        this.table.selection.rebuild();
         this.name = to;
         return this;
     }

--- a/src/tests/alter-table.queries.spec.ts
+++ b/src/tests/alter-table.queries.spec.ts
@@ -199,4 +199,11 @@ describe('Alter table', () => {
         alter table users alter column email type jsonb;
         create unique index users_by_email on users ((email->>'sha256'));`)
     });
+
+    it('can insert values referring to renamed column', () => {
+        none(`create table test("id" integer not null default 1, "col" character varying, constraint "PK" primary key ("id"));
+                  alter table test RENAME column "col" TO "newcol";
+                  insert into test(id, newcol) values (default, '1') RETURNING "id";
+        `);
+    });
 });


### PR DESCRIPTION
This should fix https://github.com/oguimbal/pg-mem/issues/340

TDD: The provided test fails without the provided fix.

Rationale: I have noticed that in many places in the code base after `this.table.db.onSchemaChange()` there is an invocation of `this.selection.rebuild()`. However this was not the case in this place.