### PR TITLE
feat: allowing bool casting

### DIFF
--- a/src/datatypes/datatypes.ts
+++ b/src/datatypes/datatypes.ts
@@ -432,6 +432,46 @@ class BoolType extends TypeBase<boolean> {
     get primary(): DataType {
         return DataType.bool;
     }
+
+    doCanCast(to: _IType): boolean | nil {
+        switch (to.primary) {
+            case DataType.text:
+            case DataType.citext:
+            case DataType.bool:
+            case DataType.integer:
+                return true;
+        }
+        return false;
+    }
+
+    doCast(value: Evaluator, to: _IType) {
+        switch (to.primary) {
+            case DataType.text:
+            case DataType.citext:
+                return new Evaluator(
+                  to
+                  , value.id
+                  , value.hash!
+                  , value
+                  , (raw, t) => {
+                      const got = value.get(raw, t);
+                      return got ? 'true' : 'false';
+                  });
+            case DataType.bool:
+                return value;
+            case DataType.integer:
+                return new Evaluator(
+                  to
+                  , value.id
+                  , value.hash!
+                  , value
+                  , (raw, t) => {
+                      const got = value.get(raw, t);
+                      return got ? 1 : 0;
+                  });
+        }
+        throw new Error('Unexpected cast error');
+    }
 }
 
 export class ArrayType extends TypeBase<any[]> {


### PR DESCRIPTION
### Title: 
Allow Casting from Boolean to other types, specifically to `integer` in `pg-mem`

### Description:

This pull request addresses the limitation in `pg-mem` where casting from boolean to integer is not allowed. This feature is important for providing complete emulation of PostgreSQL, which supports such casting.

#### Changes:

- Updated the `BoolType` class in `datatypes.ts`.
- Modified the `doCanCast()` method to include `DataType.integer`  as allowable casting targets for booleans.
- Modified the `doCast()` method to correctly cast boolean values to integers (1 for `true`, 0 for `false`).

#### Why is this change necessary?

This change is necessary to ensure that `pg-mem` can emulate PostgreSQL as accurately as possible. The absence of this feature could lead to discrepancies between the behavior of `pg-mem` and PostgreSQL, especially when testing applications that depend on this particular casting behavior.

#### How does it solve the problem?

The modifications to the `doCanCast()` and `doCast()` methods in the `BoolType` class now allow for seamless casting from boolean to integer, emulating the same behavior in PostgreSQL.

### Examples
These SQL queries should now work with `pg-mem`:

```
  select true::bool;
  select true::int;
  select true::text;
```
