### PR TITLE
fix: nothing should be returned when using on conflict do nothing (#353)

### DIFF
--- a/src/execution/records-mutations/insert.ts
+++ b/src/execution/records-mutations/insert.ts
@@ -179,7 +179,10 @@ export class Insert extends MutationDataSourceBase<any> {
                 //     toInsert[columns[i]] = converted.get();
                 // }
             }
-            ret.push(this.table.doInsert(t, toInsert, this.opts));
+            const insertedRow = this.table.doInsert(t, toInsert, this.opts)
+            if (insertedRow) {
+                ret.push(insertedRow);
+            }
         }
 
         return ret;

--- a/src/interfaces-private.ts
+++ b/src/interfaces-private.ts
@@ -417,7 +417,7 @@ export interface _ITable<T = any> extends IMemoryTable, _RelationBase {
     readonly db: _IDb;
     readonly selection: _ISelection<T>;
     readonly ownerSchema: _ISchema;
-    doInsert(t: _Transaction, toInsert: T, opts?: ChangeOpts): T;
+    doInsert(t: _Transaction, toInsert: T, opts?: ChangeOpts): T | null;
     setHidden(): this;
     setReadonly(): this;
     delete(t: _Transaction, toDelete: T): void;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -392,7 +392,7 @@ export interface IMemoryTable<T = unknown> {
      * ⚠ Neither the record you provided, nor the returned value are the actual item stored. You wont be able to mutate internal state.
      * @returns A copy of the inserted item (with assigned defaults)
      */
-    insert(item: Partial<T>): T;
+    insert(item: Partial<T>): T | null;
 
     /** Find all items matching a specific template */
     find(template?: Partial<T> | nil, columns?: (keyof T)[]): Iterable<T>;

--- a/src/table.ts
+++ b/src/table.ts
@@ -290,12 +290,15 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
         this.setBin(t, converted);
     }
 
-    insert(toInsert: T): T {
+    insert(toInsert: T): T | null {
         const ret = this.doInsert(this.db.data, deepCloneSimple(toInsert));
+        if (ret == null) {
+            return null
+        }
         return deepCloneSimple(ret);
     }
 
-    doInsert(t: _Transaction, toInsert: T, opts?: ChangeOpts): T {
+    doInsert(t: _Transaction, toInsert: T, opts?: ChangeOpts): T | null {
         if (this.readonly) {
             throw new PermissionDeniedError(this.name);
         }
@@ -337,7 +340,10 @@ export class MemoryTable<T = any> extends DataSourceBase<T> implements IMemoryTa
                             const key = k.index.buildKey(toInsert, t);
                             const found = k.index.eqFirst(key, t);
                             if (found) {
-                                return found; // ignore.
+                                // This function returns the inserted row,
+                                // but in this case we had a conflict and no row was inserted.
+                                // So we return null.
+                                return null; // ignore.
                             }
                         }
                     }

--- a/src/tests/insert.queries.spec.ts
+++ b/src/tests/insert.queries.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import 'chai';
 import { newDb } from '../db';
-import { IMemoryDb } from '../interfaces';
+import { IMemoryDb, QueryResult } from '../interfaces';
 import { assert, expect } from 'chai';
 
 describe('Inserts', () => {
@@ -194,12 +194,12 @@ describe('Inserts', () => {
             .to.deep.equal([{ ka: 'a', kb: 1, val: 'newA' }]);
     });
 
-    it('returns the right thing on conflict', () => {
+    it('does not returns on conflict do nothing', () => {
         expect(many(`create table test(ka text, kb integer, val text,  primary key (ka, kb));
                         insert into test values ('a', 1, 'oldA');
                         insert into test values ('a', 1, 'whatever')
                             on conflict do nothing returning val;`))
-            .to.deep.equal([{ val: 'oldA' }]);
+            .to.deep.equal([]);
     });
 
 

--- a/src/tests/publicapi.spec.ts
+++ b/src/tests/publicapi.spec.ts
@@ -130,6 +130,10 @@ describe('Test utils', () => {
         }
         // insert
         const inserted = table.insert(orig);
+        if (inserted == null) {
+            assert(false);
+            return; // satisfy typescript
+        }
 
         // mutate original + check query result not impacted
         mutate(orig);


### PR DESCRIPTION
when we use `insert .... on conflict do nothing`, and there is a conflict, nothing should be returned because no row was inserted. Fix the code accordingly.
See issue #353 