### PR TITLE
Fix AST coverage check error

### DIFF
--- a/src/tests/select.queries.spec.ts
+++ b/src/tests/select.queries.spec.ts
@@ -390,4 +390,10 @@ describe('Selections', () => {
             rowCount: 2,
         })
     })
+
+    it('can select fully qualified column names', () => {
+        stuff();
+        expect(many(`SELECT "public"."test"."val" FROM "public"."test"`))
+            .to.deep.equal([{ val: 999 }, { val: 0 }, { val: 1 }, { val: 2 }, { val: 3 }]);
+    });
 });

--- a/src/transforms/alias.ts
+++ b/src/transforms/alias.ts
@@ -119,8 +119,10 @@ export class Alias<T> extends TransformBase<T> implements _IAlias {
     private _getColumn(column: string | ExprRef): IValue | nil {
         if (typeof column !== 'string'
             && column.table) {
-            if (!column.table.schema
-                && column.table.name !== this.name) {
+            if (column.table.schema && column.table.schema !== this.ownerSchema.name) {
+                return null;
+            }
+            if (column.table.name !== this.name) {
                 return null;
             }
             column = column.name;


### PR DESCRIPTION
Currently when you run a query against pg-mem with fully qualified column names like `SELECT "public"."test"."val" FROM "public"."test"`, it gives you an AST coverage error like `The query you ran generated an AST which parts have not been read by the query planner. This means that those parts could be ignored:  ⇨ .columns[0].expr.table.name ("test")`. This is happening because when the query planner retrieves the column data, in some cases it never actually checks the statement table name to be sure it matches before returning the column description. This commit refactors the column retrieval code to ensure this always gets checked.

I'm not familiar enough with the internal logic of this library to know if this fix is the "correct' way of doing this so I would like feedback on whether or not there is a better solution. But this logic fix makes sense to me so I figured I would start with a PR.

I believe this should fix this old bug as well: https://github.com/oguimbal/pg-mem/issues/130