### PR TITLE
feat: add a sizable equivalent type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -342,6 +342,9 @@ export interface ISchema {
     /** Register a simple type, which is equivalent to another */
     registerEquivalentType(type: IEquivalentType): IType;
 
+    /** Register a simple type, which is equivalent to another */
+    registerEquivalentSizableType(type: IEquivalentType): IType;
+
     /** Get an existing type */
     getType(name: DataType): IType;
 

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -394,6 +394,14 @@ export class DbSchema implements _ISchema, ISchema {
     registerEquivalentType(type: IEquivalentType): IType {
         const ret = new EquivalentType(type);
         this._registerType(ret);
+
+        return ret;
+    }
+
+    registerEquivalentSizableType(type: IEquivalentType): IType {
+        const ret = new EquivalentType(type);
+        this._registerTypeSizeable(ret.primary, (_) => ret);
+
         return ret;
     }
 

--- a/src/tests/custom-types.spec.ts
+++ b/src/tests/custom-types.spec.ts
@@ -96,5 +96,17 @@ describe('Custom types', () => {
         expectQueryError(() => none(`SELECT 'throw'::custom`), /Nope/);
         expectQueryError(() => none(`SELECT 'whatever'::custom`), /invalid input syntax for type custom/);
         expectQueryError(() => none(`SELECT 42::custom`), /cannot cast type integer to custom/);
+    });
+
+    it('can register custom type with length', () => {
+        db.public.registerEquivalentSizableType({
+            name: 'vector',
+            equivalentTo: DataType.text,
+            isValid(val: string) {
+                return true;
+            }
+        });
+
+        none(`CREATE TABLE "test" ("embedding" vector(1536) NOT NULL)`);
     })
 });


### PR DESCRIPTION
## Background 

I'm trying to extend pg-mem to support [pgvector](https://github.com/pgvector/pgvector), a popular library that's used for vector similarity search. 

The core feature of pgvector is a new column type "vector". 

Unfortunately, given the current API for pg-mem, I don't believe there is any way to implement vector (which is a *sizable* custom type). 

## What this pull request does

This pull request implements a new "registerEquivalentSizableType" that allows you to implement "vector". 

I'm not sure if this is the best way to implement this, so very open to feedback :) 

