### PR TITLE
fix indexed column EqFilter condition for is null operator

### DIFF
--- a/src/transforms/eq-filter.ts
+++ b/src/transforms/eq-filter.ts
@@ -28,7 +28,12 @@ export class EqFilter extends FilterBase {
     }
 
     hasItem(item: Row, t: _Transaction) {
+        const isEq = this.op === 'eq';
         const val = this.onValue.get(item, t);
+
+        if (this.matchNull && nullIsh(val)) {
+            return isEq;
+        }
         if (nullIsh(val)) {
             return false;
         }
@@ -36,7 +41,7 @@ export class EqFilter extends FilterBase {
         if (nullIsh(eq)) {
             return false;
         }
-        return this.op === 'eq' ? !!eq : !eq;
+        return isEq ? !!eq : !eq;
     }
 
     constructor(private onValue: IValue


### PR DESCRIPTION
### Background
`EqFilter` class while working as expected in most conditions, didn't respect `matchNull` flag in cases when it was nested in secondary-order filters. This PR adds support for such `IS NULL` usage