### PR TITLE
fix: set correct 'table_schema' in information_schema.tables

### DIFF
--- a/src/schema/information-schema/table-list.ts
+++ b/src/schema/information-schema/table-list.ts
@@ -52,7 +52,7 @@ export class TablesSchema extends ReadOnlyTable implements _ITable {
         }
         const ret = {
             table_catalog: 'pgmem',
-            table_schema: 'public',
+            table_schema: t.ownerSchema.name || 'public',
             table_name: t.name,
             table_type: 'BASE TABLE',
             self_referencing_column_name: null,

--- a/src/tests/simple-queries.spec.ts
+++ b/src/tests/simple-queries.spec.ts
@@ -269,6 +269,12 @@ describe('Simple queries', () => {
             .toEqual([{ hasuserstable: 0 }]);
     })
 
+    it('can select info tables with table schema', () => {
+        none(`create schema custom_schema;
+            create table custom_schema.test(id text);`)
+        expect(many(`select table_name from information_schema.tables where table_name = 'test' and table_schema = 'custom_schema';`))
+            .toEqual([{ table_name: 'test' }]);
+    });
 
     it('can select info columns', () => {
         simpleDb();


### PR DESCRIPTION
### Background
Right now all tables added to `information_schema.tables` are always added with table_schema = 'public'. 
This is a problem when using a schema different than 'public' when using pg-mem + knex because, when running migrations, knex queries the `information_schema.tables` table to determine if the knex migration tables have been created successfully.

### Before:
<img width="1003" alt="Screenshot 2025-01-02 at 7 17 39 PM" src="https://github.com/user-attachments/assets/2bdbc8bf-89c5-493c-a5e0-2bec2bd08543" />

### After:
<img width="493" alt="Screenshot 2025-01-02 at 7 17 24 PM" src="https://github.com/user-attachments/assets/7f3587a3-a363-4ba4-8840-ef5ddfe62a8a" />
