### PR TITLE
Fix "DROP COLUMN doesn't drop the constraint"

### DIFF
--- a/src/tests/alter-table.queries.spec.ts
+++ b/src/tests/alter-table.queries.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, xit, beforeEach, expect } from 'bun:test';
+import { describe, it, beforeEach, expect } from 'bun:test';
 
 import { newDb } from '../db';
 
@@ -214,14 +214,14 @@ describe('Alter table', () => {
         `);
     });
 
-	xit('(bugfix) drops the constraint after dropping a column', async () => {
-		none(`
-			 CREATE TABLE "parent" ("id" INTEGER PRIMARY KEY, "value" INTEGER);
-			 CREATE TABLE "child" ("id" INTEGER PRIMARY KEY, "parent_id" INTEGER NOT NULL REFERENCES "parent"("id"));
-			 INSERT INTO "parent"("id", "value") VALUES (1, 42);
-			 INSERT INTO "child"("id", "parent_id") VALUES (1, 1);
-			 ALTER TABLE "child" DROP COLUMN "parent_id";
-			 DELETE FROM "parent" WHERE "id" = 1
-		`);
-	});
+    it('(bugfix) drops the constraint after dropping a column', async () => {
+        none(`
+             CREATE TABLE "parent" ("id" INTEGER PRIMARY KEY, "value" INTEGER);
+             CREATE TABLE "child" ("id" INTEGER PRIMARY KEY, "parent_id" INTEGER NOT NULL REFERENCES "parent"("id"));
+             INSERT INTO "parent"("id", "value") VALUES (1, 42);
+             INSERT INTO "child"("id", "parent_id") VALUES (1, 1);
+             ALTER TABLE "child" DROP COLUMN "parent_id";
+             DELETE FROM "parent" WHERE "id" = 1
+             `);
+    });
 });


### PR DESCRIPTION
Fix for issue: #469

The fix fixes provided in PR test case.

I created a `Set` of constraints in order to uninstall them once column is dropped. I only added foreign keys. Maybe some other constraints should be added there, I'm not sure. 