### PR TITLE
fix: GREATEST/LEAST should ignore null arguments

### DIFF
--- a/src/functions/numbers.ts
+++ b/src/functions/numbers.ts
@@ -1,4 +1,4 @@
-import { DataType, FunctionDefinition } from "../interfaces";
+import { DataType, FunctionDefinition, nil } from "../interfaces";
 
 export const numberFunctions: FunctionDefinition[] = [
     {
@@ -6,13 +6,21 @@ export const numberFunctions: FunctionDefinition[] = [
         args: [DataType.integer],
         argsVariadic: DataType.integer,
         returns: DataType.integer,
-        implementation: (...args: number[]) => Math.max(...args),
+        allowNullArguments: true,
+        implementation: (...args: (number | nil)[]) => {
+            const values = args.filter((x): x is number => x !== null && x !== undefined);
+            return values.length ? Math.max(...values) : null;
+        },
     },
     {
         name: 'least',
         args: [DataType.integer],
         argsVariadic: DataType.integer,
         returns: DataType.integer,
-        implementation: (...args: number[]) => Math.min(...args),
+        allowNullArguments: true,
+        implementation: (...args: (number | nil)[]) => {
+            const values = args.filter((x): x is number => x !== null && x !== undefined);
+            return values.length ? Math.min(...values) : null;
+        },
     },
 ]

--- a/src/tests/function-calls.spec.ts
+++ b/src/tests/function-calls.spec.ts
@@ -55,6 +55,21 @@ describe('Functions', () => {
             .toEqual([{ least: 1 }]);
     });
 
+    it('GREATEST ignores null arguments', () => {
+        expect(many(`select GREATEST(1, null, 3) as v;`))
+            .toEqual([{ v: 3 }]);
+    });
+
+    it('LEAST ignores null arguments', () => {
+        expect(many(`select LEAST(2, null, 1) as v;`))
+            .toEqual([{ v: 1 }]);
+    });
+
+    it('GREATEST returns null when all arguments are null', () => {
+        expect(many(`select GREATEST(null::int, null) as v;`))
+            .toEqual([{ v: null }]);
+    });
+
     it('can declare & call function', () => {
         db.registerLanguage('mylang', ({ code, args, returns }) => {
             expect(code).toBe('some code');


### PR DESCRIPTION
### Problem

`GREATEST` and `LEAST` return `null` as soon as any single argument is null:

```sql
select greatest(1, null, 3);  -- pg-mem: null
select least(2, null, 1);     -- pg-mem: null
```

Postgres ignores null arguments in these functions, and returns null only when every argument is null:

```sql
select greatest(1, null, 3);       -- postgres: 3
select least(2, null, 1);          -- postgres: 1
select greatest(null::int, null);  -- postgres: null
```

Ref: [Postgres conditional expressions (GREATEST/LEAST)](https://www.postgresql.org/docs/current/functions-conditional.html) - null values in the argument list are ignored, and the result is null only if all arguments are null.

### Cause

Both functions were declared without `allowNullArguments`, so a null argument short-circuited the whole call to null before the implementation ran.

### Fix

Set `allowNullArguments: true` and filter nulls inside the implementation, returning null only when all arguments are null. Unit tests added in `function-calls.spec.ts`.
