### PR TITLE
fix: concat_ws should skip null values and honour a null separator

### DIFF
--- a/src/functions/string.ts
+++ b/src/functions/string.ts
@@ -1,4 +1,4 @@
-import { DataType, FunctionDefinition } from '../interfaces-private';
+import { DataType, FunctionDefinition, nil } from '../interfaces-private';
 
 export const stringFunctions: FunctionDefinition[] = [
     {
@@ -27,6 +27,11 @@ export const stringFunctions: FunctionDefinition[] = [
         argsVariadic: DataType.text,
         returns: DataType.text,
         allowNullArguments: true,
-        implementation: (separator: string, ...x: string[]) => x?.join(separator),
+        implementation: (separator: string | nil, ...x: (string | nil)[]) => {
+            if (separator === null || separator === undefined) {
+                return null;
+            }
+            return x.filter(v => v !== null && v !== undefined).join(separator);
+        },
     },
 ]

--- a/src/tests/function-calls.spec.ts
+++ b/src/tests/function-calls.spec.ts
@@ -35,6 +35,21 @@ describe('Functions', () => {
             .toEqual([{ concat: 'text-123-end' }]);
     });
 
+    it('concat_ws skips null arguments', () => {
+        expect(many(`select concat_ws(',', 'a', null, 'b') as v;`))
+            .toEqual([{ v: 'a,b' }]);
+    });
+
+    it('concat_ws returns null when the separator is null', () => {
+        expect(many(`select concat_ws(null, 'a', 'b') as v;`))
+            .toEqual([{ v: null }]);
+    });
+
+    it('concat_ws returns an empty string when every value is null', () => {
+        expect(many(`select concat_ws(',', null, null) as v;`))
+            .toEqual([{ v: '' }]);
+    });
+
     it('GREATEST 2 arguments', () => {
         expect(many(`select GREATEST(0, -1);`))
             .toEqual([{ greatest: 0 }]);


### PR DESCRIPTION
### Problem

`concat_ws` mishandles nulls three ways:

```sql
select concat_ws(',', 'a', null, 'b');  -- pg-mem: 'a,,b'
select concat_ws(null, 'a', 'b');       -- pg-mem: 'anullb'
select concat_ws(',', null, null);      -- pg-mem: ','
```

Postgres skips null value arguments, returns null when the separator is null, and returns an empty string when every value argument is null:

```sql
select concat_ws(',', 'a', null, 'b');  -- postgres: 'a,b'
select concat_ws(null, 'a', 'b');       -- postgres: null
select concat_ws(',', null, null);      -- postgres: ''
```

Ref: [Postgres string functions (concat_ws)](https://www.postgresql.org/docs/current/functions-string.html)

### Cause

The implementation was `(separator, ...x) => x?.join(separator)`, which turns each null value into an empty field (the separator is still emitted), coerces a null separator to the string `"null"`, and can never return null.

### Fix

Return null when the separator is null, and skip null values before joining (an all-null value list yields an empty string). Unit tests added in `function-calls.spec.ts`.
