### PR TITLE
fix: substring window is wrong for start positions below 1

### DIFF
--- a/src/parser/expression-builder.ts
+++ b/src/parser/expression-builder.ts
@@ -832,7 +832,7 @@ function buildOverlay(op: ExprOverlay): IValue {
             if (nullIsh(_from)) {
                 return null;
             }
-            const before = sqlSubstring(_value, 0, _from - 1);
+            const before = sqlSubstring(_value, 1, _from - 1);
             let after: string | nil;
             if (forr) {
                 const _for = forr.get(raw, t) as number;
@@ -872,7 +872,7 @@ function buildSubstring(op: ExprSubstring): IValue {
             if (nullIsh(_value)) {
                 return null;
             }
-            let start = 0;
+            let start = 1;
             let len: number | nil;
             if (from) {
                 start = from.get(raw, t) as number;
@@ -896,14 +896,13 @@ export function sqlSubstring(value: string, from = 0, len?: number | nil): strin
     }
     // sql substring is base-1
     from--;
-    if (from < 0) {
-        from = 0;
-    }
     if (!nullIsh(len)) {
         if (len! < 0) {
             throw new QueryError('negative substring length not allowed');
         }
-        return value.substr(from, len!);
+        const end = from + len!;
+        const start = from < 0 ? 0 : from;
+        return end <= start ? '' : value.substring(start, end);
     }
-    return value.substr(from);
+    return from < 0 ? value : value.substr(from);
 }

--- a/src/tests/simple-queries.spec.ts
+++ b/src/tests/simple-queries.spec.ts
@@ -428,6 +428,9 @@ describe('Simple queries', () => {
             [`select substring('012345678' from 1) as v`, '012345678'],
             [`select substring('012345678' from 0) as v`, '012345678'],
             [`select substring('012345678' from -1) as v`, '012345678'],
+            [`select substring('012345678' from 0 for 3) as v`, '01'],
+            [`select substring('012345678' from -1 for 3) as v`, '0'],
+            [`select substring('012345678' from -5 for 2) as v`, ''],
         ]) {
             it(k, () => {
                 expect(many(k))


### PR DESCRIPTION
### Problem

`substring(str from S for L)` selects the window `[S, S+L)` clipped to valid (>= 1) positions. When `S` is below 1, pg-mem applies the length from the clamped start (position 1) instead of the original `S`, so it returns too many characters:

```sql
select substring('012345678' from 0 for 3);   -- pg-mem: '012', postgres: '01'
select substring('012345678' from -1 for 3);  -- pg-mem: '012', postgres: '0'
select substr('012345678', 0, 3);              -- pg-mem: '012', postgres: '01'
```

The same `sqlSubstring` helper backs the `substring`/`substr` functions and the `substring(... from ... for ...)` form.

Ref: [Postgres string functions](https://www.postgresql.org/docs/current/functions-string.html)

### Cause

`sqlSubstring` clamped the start to 0 but still passed the full length to `substr(start, len)`, so the window's end shifted right by the amount that was clamped off the front.

### Fix

Compute the window end from the original start (`end = from + len`), clamp only the start, and return an empty string when the window ends at or before the start. Also default an omitted `FROM` to position 1 (so `substring(x for n)` is unchanged) and update `overlay()`, which passed `from = 0` relying on the old clamp. Tests added in `simple-queries.spec.ts`.
