### PR TITLE
fix: LIKE ignores the backslash escape character

### DIFF
--- a/src/tests/operators.queries.spec.ts
+++ b/src/tests/operators.queries.spec.ts
@@ -420,6 +420,34 @@ describe('Operators', () => {
                 ]);
         });
 
+        it('executes like with an escaped percent sign', () => {
+            expect(many(`create table test(val text);
+                insert into test values ('a%b'), ('axb'), ('a_b'), (null);
+                select * from test where val like 'a\\%b'`))
+                .toEqual([
+                    { val: 'a%b' }
+                ]);
+        });
+
+        it('executes like with an escaped underscore', () => {
+            expect(many(`create table test(val text);
+                insert into test values ('a_b'), ('axb'), ('a%b'), (null);
+                select * from test where val like 'a\\_b'`))
+                .toEqual([
+                    { val: 'a_b' }
+                ]);
+        });
+
+        it('executes like with an escaped percent sign on an indexed column', () => {
+            expect(many(`create table test(val text);
+                create index on test(val);
+                insert into test values ('a%b'), ('axb'), ('a_b'), (null);
+                select * from test where val like 'a\\%b'`))
+                .toEqual([
+                    { val: 'a%b' }
+                ]);
+        });
+
 
         it('executes not like', () => {
             expect(many(`create table test(val text);

--- a/src/transforms/build-filter.ts
+++ b/src/transforms/build-filter.ts
@@ -131,7 +131,8 @@ function buildBinaryFilter(this: void, on: _ISelection, filter: ExprBinary): _IS
                     if (nullIsh(str)) {
                         return new FalseFilter(on);
                     }
-                    const got = /^([^%_]+)([%_]?.+)$/.exec(str);
+                    const got = String(str).indexOf('\\') === -1
+                        && /^([^%_]+)([%_]?.+)$/.exec(str);
                     if (got) {
                         const start = got[1];
                         if (start.length === str) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,11 +290,26 @@ export function queryJson(a: Json, b: Json) {
     return true;
 }
 
+function escapeRegexChar(char: string): string {
+    return char.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 export function buildLikeMatcher(likeCondition: string, caseSensitive = true) {
-    // Escape regex characters from likeCondition
-    likeCondition = likeCondition.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-    let likeRegexString = likeCondition.replace(/\%/g, ".*").replace(/_/g, '.');
-    likeRegexString = "^" + likeRegexString + "$";
+    let likeRegexString = '^';
+    for (let i = 0; i < likeCondition.length; i++) {
+        const char = likeCondition[i];
+        if (char === '\\') {
+            const escaped = likeCondition[++i];
+            likeRegexString += escaped === undefined ? '\\\\' : escapeRegexChar(escaped);
+        } else if (char === '%') {
+            likeRegexString += '.*';
+        } else if (char === '_') {
+            likeRegexString += '.';
+        } else {
+            likeRegexString += escapeRegexChar(char);
+        }
+    }
+    likeRegexString += '$';
     const reg = new RegExp(likeRegexString, caseSensitive ? '' : 'i');
 
     return (stringToMatch: string | number) => {


### PR DESCRIPTION
### Problem

LIKE ignored the escape character (backslash by default), so an escaped wildcard did not match its literal:

```sql
select 'a%b' like 'a\%b';   -- pg-mem: false, postgres: true
select 'a_b' like 'a\_b';   -- pg-mem: false, postgres: true
```

The same happened on an indexed column: the literal prefix was taken from the raw pattern (`a\` instead of `a%b`), so the index narrowing dropped matching rows.

Ref: [Postgres LIKE](https://www.postgresql.org/docs/current/functions-matching.html)

### Cause

`buildLikeMatcher` regex-escaped the whole pattern and then replaced every `%`/`_`, with no notion of the escape character, so `\%` stayed a wildcard (and left a stray backslash in the regex). The index fast-path in `build-filter` extracted its prefix straight from the raw pattern.

### Fix

`buildLikeMatcher` now parses the pattern in a single pass: a backslash escapes the next character (so `\%`, `\_` and `\\` match a literal `%`, `_` and `\`), while unescaped `%`/`_` remain wildcards. The index prefix optimisation bails out for patterns containing an escape character and falls back to a sequential scan with the corrected matcher. Tests added in `operators.queries.spec.ts`, including an indexed case.
